### PR TITLE
Updating gulp-sass in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gulp-closure-compiler": "^0.2.17",
     "gulp-concat": "^2.5.2",
     "gulp-plumber": "^1.0.0",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.1.1",
     "gulp-uglify": "^1.2.0",
     "run-sequence": "^1.0.2"
   }


### PR DESCRIPTION
The current version of gulp-sass (v1.3.3) fails to install correctly whenever I start a new project using this scaffold. It seems like npm is unable to download the node-sass dependency, resulting in "Build failed" every time. I've been updating this manually to 2.1.1 for each of my projects and haven't experienced any issues with my css
