### PR TITLE
Update closure-library reference

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,6 @@ gulp.task('compile_js', function() {
         'js': [
             './bower_components/closure-library/closure/**.js',
             './bower_components/closure-library/third_party/**.js',
-            './source/js/**.js',
             '!**_test.js'
         ]
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('compile_js', function() {
         'only_closure_dependencies': true,
         'output_wrapper': '(function(){%output%})();',
         'js': [
-            './bower_components/closure-library/**.js',
+            './bower_components/closure-library/closure/**.js',
             './source/js/**.js',
             '!**_test.js'
         ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,6 +50,7 @@ gulp.task('compile_js', function() {
         'output_wrapper': '(function(){%output%})();',
         'js': [
             './bower_components/closure-library/closure/**.js',
+            './bower_components/closure-library/third_party/**.js',
             './source/js/**.js',
             '!**_test.js'
         ]


### PR DESCRIPTION
- Fix issue where require not found is present using high level closure-library folder
- Uses nested `closure` folder to fix above issue and removing compiling tests.
